### PR TITLE
Add link to API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ lookups, splits by index or key and subsets/submaps.
 
 Persistent AVL trees are used as the underlying data structure.
 
+## API Documentation
+
+API docs are available as:
+ - the project API reference:  https://clojure.github.io/data.avl/
+ - codox on GitHub pages:      http://cloojure.github.io/doc/data.avl/
+
 ## Synopsis
 
 data.avl supports both Clojure and ClojureScript. It exports a single


### PR DESCRIPTION
Hi - I noticed there wasn't a link to the API docs.  I created a sample using codox (for a private copy of the repo) before I accidentally found the one at https://clojure.github.io/data.avl      

I left in both versions as a "sample" change.  I kind of like the codox version as it doesn't include the private details of the impl. However, we could keep only the clojure.githib.io version if you prefer.

Alan