### PR TITLE
update cljs data.avl maps to return MapEntries instead of 2-elem vectors to comply with clj 1.9 and cljs 1.9.293 and later

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
+	<groupId>com.github.kaosko</groupId>
   <artifactId>data.avl</artifactId>
   <version>0.0.19-SNAPSHOT</version>
   <name>data.avl</name>
@@ -35,7 +36,7 @@
   </scm>
 
   <properties>
-    <clojure.version>1.5.1</clojure.version>
+    <clojure.version>1.9.0</clojure.version>
     <clojure.warnOnReflection>true</clojure.warnOnReflection>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
 	<groupId>com.github.kaosko</groupId>
   <artifactId>data.avl</artifactId>
-  <version>0.0.19</version>
+  <version>0.0.20-SNAPSHOT</version>
   <name>data.avl</name>
   <description>Persistent sorted maps and sets with log-time rank queries</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
 	<groupId>com.github.kaosko</groupId>
   <artifactId>data.avl</artifactId>
-  <version>0.0.19-SNAPSHOT</version>
+  <version>0.0.19</version>
   <name>data.avl</name>
   <description>Persistent sorted maps and sets with log-time rank queries</description>
 

--- a/src/main/cljs/clojure/data/avl.cljs
+++ b/src/main/cljs/clojure/data/avl.cljs
@@ -611,7 +611,7 @@
                 (cond
                   (zero? c)
                   [(.getLeft node)
-                   [(.getKey node) (.getVal node)]
+                   (MapEntry. (.getKey node) (.getVal node) nil)
                    (.getRight node)]
 
                   (neg? c)
@@ -697,7 +697,7 @@
                (avl-map-reduce (.getLeft node) f init))]
     (if (reduced? init)
       init
-      (let [init (f init [(.getKey node) (.getVal node)])]
+      (let [init (f init (MapEntry. (.getKey node) (.getVal node) nil))]
         (if (reduced? init)
           init
           (if (nil? (.getRight node))
@@ -714,7 +714,7 @@
         (if (nil? (.getRight node))
           init
           (avl-map-reduce (.getRight node) f init))
-        (let [init (f init [(.getKey node) (.getVal node)])]
+        (let [init (f init (MapEntry. (.getKey node) (.getVal node) nil))]
           (if (reduced? init)
             init
             (if (nil? (.getRight node))
@@ -768,7 +768,7 @@
   ISeq
   (-first [this]
     (let [node (peek stack)]
-      [(.-key node) (.-val node)]))
+      (MapEntry. (.-key node) (.-val node) nil)))
 
   (-rest [this]
     (let [node (first stack)
@@ -828,7 +828,7 @@
 
   (nearest [this test k]
     (if-let [node (lookup-nearest comp tree test k)]
-      [(.getKey node) (.getVal node)]))
+      (MapEntry. (.getKey node) (.getVal node) nil)))
 
   IHash
   (-hash [this]
@@ -849,12 +849,12 @@
   IIndexed
   (-nth [this i]
     (if-let [n (select tree i)]
-      [(.getKey n) (.getVal n)]
+      (MapEntry. (.getKey n) (.getVal n) nil)
       (throw (ex-info "nth index out of bounds in AVL tree" {}))))
 
   (-nth [this i not-found]
     (if-let [n (select tree i)]
-      [(.getKey n) (.getVal n)]
+      (MapEntry. (.getKey n) (.getVal n) nil)
       not-found))
 
   ICollection
@@ -884,9 +884,9 @@
   (-reduce [this f]
     (case cnt
       0 (f)
-      1 [(.getKey tree) (.getVal tree)]
+      1 (MapEntry. (.getKey tree) (.getVal tree) nil)
       (let [n0 (select tree 0)
-            init (avl-map-reduce-skip tree f [(.getKey n0) (.getVal n0)] n0)]
+            init (avl-map-reduce-skip tree f (MapEntry. (.getKey n0) (.getVal n0) nil) n0)]
         (if (reduced? init)
           (-deref init)
           init))))
@@ -1210,7 +1210,7 @@
   AVLSet
   (-pr-writer [this writer opts]
     (pr-sequential-writer writer pr-writer "#{" " " "}" opts this)))
-
+    
 (defn sorted-map
   "keyval => key val
   Returns a new AVL map with supplied mappings."


### PR DESCRIPTION
Now, I understand you don't accept pull requests for data.avl but just creating this to make a note of the issue, the actual changes are trivial. PersistentVectors in clj 1.9 are not allowed as MapEntries anymore; since cljs 1.9.229 2-elem vectors are not treated as MapEntries. However, cljs-version of data.avl returns 2-elem vectors instead of MapEntries. Actual issue at https://dev.clojure.org/jira/browse/DAVL-11